### PR TITLE
fix #26 by removing invalid instructions

### DIFF
--- a/zendnnl/src/common/float16.hpp
+++ b/zendnnl/src/common/float16.hpp
@@ -185,37 +185,6 @@ class float16_t {
   uint16_t raw_bits_; /*!< float16 raw bits (IEEE 754 half-precision) */
 };
 
-#if defined(__GNUC__) && (__GNUC__ >= 12)
-//===----------------------------------------------------------------------===//
-// AVX-512-FP16 masked load/store shims
-//
-// GCC 12 and 13 ship AVX-512-FP16 intrinsics but are missing
-// _mm512_maskz_loadu_ph and _mm512_mask_storeu_ph (added in GCC 14).
-// Both lower to the same VMOVDQU16 instruction as their epi16
-// counterparts, so on GCC < 14 we forward to the epi16 form. On
-// GCC >= 14, the real intrinsics are used. Defined inline in this
-// header so they always inline at the call site.
-//===----------------------------------------------------------------------===//
-
-__attribute__((always_inline, target("avx512f,avx512vl,avx512bw,avx512fp16")))
-static inline __m512h f16_maskz_loadu_vec(__mmask32 k, const void *addr) {
-#if (__GNUC__ < 14)
-  return (__m512h)_mm512_maskz_loadu_epi16(k, addr);
-#else
-  return _mm512_maskz_loadu_ph(k, addr);
-#endif
-}
-
-__attribute__((always_inline, target("avx512f,avx512vl,avx512bw,avx512fp16")))
-static inline void f16_mask_storeu_vec(void *addr, __mmask32 k, __m512h val) {
-#if (__GNUC__ < 14)
-  _mm512_mask_storeu_epi16(addr, k, (__m512i)val);
-#else
-  _mm512_mask_storeu_ph(addr, k, val);
-#endif
-}
-#endif  // __GNUC__ >= 12
-
 }//namespace common
 
 namespace interface {

--- a/zendnnl/src/operators/embag/native_kernels/embag_avx512_f16_utils.hpp
+++ b/zendnnl/src/operators/embag/native_kernels/embag_avx512_f16_utils.hpp
@@ -36,10 +36,6 @@ namespace ops {
 #if __GNUC__ >= 12
 
 using common::float16_t;
-// Pull the masked-PH load/store shims from common into ops scope so that
-// the F16 (no-conversion) path can call them directly.
-using common::f16_maskz_loadu_vec;
-using common::f16_mask_storeu_vec;
 
 /*-----------------------------------------------------------------------------
   embag_avx512_f16_fma_kernel:
@@ -89,7 +85,7 @@ __attribute__((always_inline, target("avx512f,avx512vl,avx512bw,avx512fp16")))
 static inline __m512h f16_load_tail(const InType *src, int tail) {
   if constexpr(std::is_same_v<InType, float16_t>) {
     __mmask32 mask = (1u << tail) - 1;
-    return f16_maskz_loadu_vec(mask, src);
+    return (__m512h)_mm512_maskz_loadu_epi16(mask, src);
   }
   else {
     const float *fp = reinterpret_cast<const float *>(src);
@@ -133,7 +129,7 @@ __attribute__((always_inline, target("avx512f,avx512vl,avx512bw,avx512fp16")))
 static inline void f16_store_tail(OutType *dst, __m512h val, int tail) {
   if constexpr(std::is_same_v<OutType, float16_t>) {
     __mmask32 mask = (1u << tail) - 1;
-    f16_mask_storeu_vec(dst, mask, val);
+    _mm512_mask_storeu_epi16(dst, mask, (__m512i)val);
   }
   else {
     float *fp = reinterpret_cast<float *>(dst);


### PR DESCRIPTION
After @vpirogov confirmed the issue and pointed me in the direction of it being hallucinated instructions, I went looking for these and could not find them referenced anywhere (for example https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html), so this PR removes that whole chunk of code and inlines the working path.

AI usage disclosure: none, I hand-modified these although I am not super experienced with c++.